### PR TITLE
WIP: Drop parallel's apply for futurized counterpart

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,6 @@ Imports:
     digest,
     rpart,
     rpart.plot (>= 3.0.6),
-    parallel,
     plotrix,
     cluster,
     stringr,
@@ -30,7 +29,8 @@ Imports:
     zoo,
     crayon,
     clisymbols,
-    testthat
+    testthat,
+    future.apply
 Suggests:
     knitr,
     rmarkdown,

--- a/R/partialDependencePlot.R
+++ b/R/partialDependencePlot.R
@@ -21,11 +21,9 @@ partialDependencePlot <- function(forest, reference.var, reference.param, suppor
 #' @param reference.param Label of the (dependent) model parameter for which
 #' partial dependence is plotted
 #' @param support Number of grid points for interpolating the reference.var
-#' @param cluster A reference to a cluster from parallel package for parallel
-#' execution. Defaults to NULL for sequential computation.
 #' @author Andreas M. Brandmaier
 #' @export
-partialDependence <- function(forest, reference.var, reference.param, support=NULL, cluster=NULL) 
+partialDependence <- function(forest, reference.var, reference.param, support=NULL)
 {
   
   result <- list()
@@ -105,11 +103,7 @@ partialDependence <- function(forest, reference.var, reference.param, support=NU
     return(ret)
   }
   
-  if (is.null(cluster)) {
-    mapresult <- lapply(FUN=mapreduce,X=forest$forest)
-  } else {
-    mapresult <- parallel::parLapply(cl=cluster,fun=mapreduce,X=forest$forest)
-  }
+  mapresult <- future.apply::future_lapply(FUN=mapreduce,X=forest$forest)
   
   #result <- list()
   #for (i in 1:10) {

--- a/demo/focusParameter.R
+++ b/demo/focusParameter.R
@@ -8,6 +8,8 @@
 #
 #
 require("semtree")
+require("future")
+plan(multisession)
 
 N.sub <- 200
 
@@ -63,7 +65,6 @@ result <- mxRun(model)
 summary(result)
 
 
-cl <- parallel::makeCluster(7)
 ctrl <- semforest.control(num.trees = 210)
 
 constraints1 <- semtree.constraints(focus.parameters = "mux1")
@@ -71,18 +72,18 @@ constraints2 <- semtree.constraints(focus.parameters = "VAR_x1")
 
 
 forest <- semforest(model = model, data = data, 
-                    constraints=NULL, cluster=cl,control = ctrl)
+                    constraints=NULL, control = ctrl)
 
 forest.constrained1 <- semforest(model = model, data = data, 
-                                constraints=constraints1, cluster=cl,control = ctrl)
+                                constraints=constraints1, control = ctrl)
 forest.constrained2 <- semforest(model = model, data = data, 
-                                 constraints=constraints2, cluster=cl,control = ctrl)
+                                 constraints=constraints2, control = ctrl)
 
 
-vim.constrained1 <- varimp(forest.constrained1, cluster = cl)
-vim.constrained2 <- varimp(forest.constrained2, cluster = cl)
+vim.constrained1 <- varimp(forest.constrained1)
+vim.constrained2 <- varimp(forest.constrained2)
 
-vim <- varimp(forest, cluster = cl)
+vim <- varimp(forest)
 
 opar <- par(no.readonly = TRUE)
 par(mfrow=c(3,1))

--- a/demo/partialDependence.R
+++ b/demo/partialDependence.R
@@ -1,6 +1,8 @@
 ## SEM Forest demo using parallel package
 
 require("semtree")
+require("future")
+plan(multisession)
 
 # ORGANIZE DATA BY TYPE FOR COVARIATES.
 # SOME COVARIATES ARE ORGANIZED IN THE DATA. MODEL VARIABLES AND 
@@ -93,9 +95,7 @@ tree <- semtree(lgcModel, lgcm)
 
 control <- semforest.control(num.trees = 7)
 
-cl <- parallel::makeCluster(7)
-
-forest <- semforest(model=lgcModel, data=lgcm, control=control, cluster=cl)
+forest <- semforest(model=lgcModel, data=lgcm, control=control)
 
 #tdep <- partialDependence(forest, reference.var="training", reference.par="means")
 depnoise <- partialDependence(forest, reference.var="noise", reference.par="means")

--- a/demo/partialDependence2.R
+++ b/demo/partialDependence2.R
@@ -8,6 +8,8 @@
 #
 #
 require("semtree")
+require("future")
+plan(multisession)
 
 N.sub <- 200
 
@@ -65,24 +67,23 @@ summary(result)
 ## - single tree -
 tree<-semtree(model, data)
 
-cl <- parallel::makeCluster(7)
 ctrl <- semforest.control(num.trees = 210)
 
 constraints <- semtree.constraints(focus.parameters = "mux1")
 
-forest <- semforest(model = model, data = data, control = ctrl, cluster = cl)
+forest <- semforest(model = model, data = data, control = ctrl)
 
 #semforest(model = model, data = data, constraints=constraints)
 
-vim <- varimp(forest,cluster =  cl)
+vim <- varimp(forest)
 
 print(vim, aggregate="median")
 print(vim, aggregate="mean")
 
-pd1.mu <- partialDependence(forest, "p1", "mux1", cluster=cl)
-pd1.var <- partialDependence(forest, "p1", "VAR_x1", cluster=cl)
-pd3.mu <- partialDependence(forest, "p3", "mux1", cluster=cl)
-pd3.var <- partialDependence(forest, "p3", "VAR_x1", cluster=cl)
+pd1.mu <- partialDependence(forest, "p1", "mux1")
+pd1.var <- partialDependence(forest, "p1", "VAR_x1")
+pd3.mu <- partialDependence(forest, "p3", "mux1")
+pd3.var <- partialDependence(forest, "p3", "VAR_x1")
 plot(pd)
 
 opar <- par(no.readonly = TRUE)

--- a/demo/seeds.R
+++ b/demo/seeds.R
@@ -1,8 +1,9 @@
 #
 # Reproducibility with semtree and parallel processing
-# using seeds and seeds on clusters
+# using multisession future strategy
 #
 require("semtree")
+require("future")
 
 #
 # (0) set up a dummy model and dataset. Scroll further down for the 
@@ -84,6 +85,7 @@ forest <- semforest(model=lgcModel, data=lgcm)
 # (1) setting seeds for local computations to make
 #   variable importance computation reproducible
 #
+plan(sequential)
 
 # compute variable importance
 set.seed(123)
@@ -97,32 +99,17 @@ vim2 <- varimp(forest)
 # they really should be given the same seed
 all(vim$importance==vim2$importance,na.rm = TRUE)
 
-#
-# (2) This is how to *NOT* set seeds when using parallel computations
-#
 
-# compute variable importance using cluster
-cl <- parallel::makeCluster(4)
+#
+# (2) Future functions in this packages are configured
+# with future.seed = T and should also return the same
+# variable importance
+
+plan(multisession)
+
 set.seed(123)
-vim <- varimp(forest, cluster=cl)
-
+vim <- varimp(forest)
 set.seed(123)
-vim2 <- varimp(forest, cluster=cl)
-
-# check whether results are identical between vim and vim2
-# they will with probability of almost 1 be not identical
-# since seeds were set only on the local process but not on
-# the cluster processes
-all(vim$importance==vim2$importance,na.rm = TRUE)
-
-
-#
-# (3) This is how to set seeds when using parallel computations
-#
-parallel::clusterSetRNGStream(cl, 123)
-vim <- varimp(forest, cluster=cl)
-
-parallel::clusterSetRNGStream(cl, 123)
-vim2 <- varimp(forest, cluster=cl)
+vim2 <- varimp(forest)
 
 all(vim$importance==vim2$importance,na.rm = TRUE)

--- a/demo/semforestLGCModelOpenMx.R
+++ b/demo/semforestLGCModelOpenMx.R
@@ -2,6 +2,8 @@
 
 # INSTALL THE PACKAGE
 require("semtree")
+require("future")
+plan(multisession)
 
 # ORGANIZE DATA BY TYPE FOR COVARIATES.
 # SOME COVARIATES ARE ORGANIZED IN THE DATA. MODEL VARIABLES AND 

--- a/demo/semforestLGCModelOpenMxParallel.R
+++ b/demo/semforestLGCModelOpenMxParallel.R
@@ -1,6 +1,8 @@
 ## SEM Forest demo using parallel package
 
 require("semtree")
+require("future")
+plan(multisession)
 
 # ORGANIZE DATA BY TYPE FOR COVARIATES.
 # SOME COVARIATES ARE ORGANIZED IN THE DATA. MODEL VARIABLES AND 
@@ -85,9 +87,7 @@ forest <- semforest(model=lgcModel, data=lgcm)
 
 control <- semforest.control(num.trees = 20)
 
-cl <- parallel::makeCluster(6)
-
-forest2 <- semforest(model=lgcModel, data=lgcm, control=control, cluster=cl)
+forest2 <- semforest(model=lgcModel, data=lgcm, control=control)
 
 # merge trees from both forest
 bigforest <- merge(forest, forest2)
@@ -95,21 +95,23 @@ bigforest <- merge(forest, forest2)
 # compute variable importance
 
 ts1 <- proc.time()
-vim <- varimp(bigforest, cluster=cl)
+plan(sequential)
+vim <- varimp(bigforest)
 ts2 <- proc.time()
+plan(multisession)
 vim2 <- varimp(bigforest)
 ts3 <- proc.time()
 
 print("Variable Importance Computation")
-print("Time with cluster")
+print("Time with sequential plan")
 print(ts2-ts1)
-print("Time without cluster")
-print(ts3-ts1)
+print("Time with multisession plan")
+print(ts3-ts2)
 
 # plot importance
 print(vim)
 plot(vim)
 
 # proximity
-prx <- proximity(bigforest, cluster=cl)
+prx <- proximity(bigforest)
 plot(prx)

--- a/demo/semforestLGCModellavaan.R
+++ b/demo/semforestLGCModellavaan.R
@@ -3,6 +3,8 @@
 
 require("semtree")
 require("lavaan")
+require("future")
+plan(multisession)
 
 # ORGANIZE DATA BY TYPE FOR COVARIATES.
 # SOME COVARIATES ARE ORGANIZED IN THE DATA. MODEL VARIABLES AND 

--- a/demo/semtreeLGCModelOpenMx.R
+++ b/demo/semtreeLGCModelOpenMx.R
@@ -2,6 +2,8 @@
 
 # INSTALL THE PACKAGE
 require("semtree")
+require("future")
+plan(multisession)
 
 # ORGANIZE DATA BY TYPE FOR COVARIATES.
 # SOME COVARIATES ARE ORGANIZED IN THE DATA. MODEL VARIABLES AND 

--- a/demo/semtreeLGCModelOpenMxInvariance.R
+++ b/demo/semtreeLGCModelOpenMxInvariance.R
@@ -2,6 +2,8 @@
 
 # INSTALL THE PACKAGE
 require("semtree")
+require("future")
+plan(multisession)
 
 # ORGANIZE DATA BY TYPE FOR COVARIATES.
 # SOME COVARIATES ARE ORGANIZED IN THE DATA. MODEL VARIABLES AND 

--- a/demo/semtreeLGCModellavaan.R
+++ b/demo/semtreeLGCModellavaan.R
@@ -3,6 +3,8 @@
 
 require("semtree")
 require("lavaan")
+require("future")
+plan(multisession)
 
 # ORGANIZE DATA BY TYPE FOR COVARIATES.
 # SOME COVARIATES ARE ORGANIZED IN THE DATA. MODEL VARIABLES AND 


### PR DESCRIPTION
This simple PR replaces all occurrances of `parallel::parXapply` with their `future.apply` counterparts. With this change you can:

+ enable users to use their own (parallel) execution strategy (the demos use `plan(multisession)`)
+ stop creating static cluster objects and stop carrying them around
+ remove some checks and code duplication
+ (imho) ignore the seed demo, because `future.seeds = T` [should take care of the RNG state](https://www.r-bloggers.com/2020/09/future-1-19-1-making-sure-proper-random-numbers-are-produced-in-parallel-processing/)

I think this branch still needs:

+ A hint for new users that, by default, future.apply does things sequentially (README or just demos?)
+ updated `docs/` and `man/` (how do you do that here exactly?)

I'm happy to include additional changes and discuss the general idea of course. Let me know :)