### PR TITLE
suggested fix for score-based tests on OpenMx models without labels 

### DIFF
--- a/R/OpenMx_scores_input.R
+++ b/R/OpenMx_scores_input.R
@@ -24,17 +24,14 @@ OpenMx_scores_input <- function(x, control) {
     m_deriv <- lapply(q_seq, function(x) {zero})
     
     for (i in q_seq) {
-#      A_deriv[[i]][which(x$A$labels == param_names[i], arr.ind = TRUE)] <- 1
       A_deriv[[i]][which(isTRUE(x$A$free), arr.ind = TRUE)] <- 1
     }
     
     for (i in q_seq) {
-#      S_deriv[[i]][which(x$S$labels == param_names[i], arr.ind = TRUE)] <- 1
       S_deriv[[i]][which(isTRUE(x$S$free), arr.ind = TRUE)] <- 1
     }
     
     for (i in q_seq) {
-#      m_deriv[[i]][which(x$M$labels == param_names[i])] <- 1
       m_deriv[[i]][which(isTRUE(x$M$labels))] <- 1
     }
     

--- a/R/OpenMx_scores_input.R
+++ b/R/OpenMx_scores_input.R
@@ -24,15 +24,18 @@ OpenMx_scores_input <- function(x, control) {
     m_deriv <- lapply(q_seq, function(x) {zero})
     
     for (i in q_seq) {
-      A_deriv[[i]][which(x$A$labels == param_names[i], arr.ind = TRUE)] <- 1
+#      A_deriv[[i]][which(x$A$labels == param_names[i], arr.ind = TRUE)] <- 1
+      A_deriv[[i]][which(isTRUE(x$A$free), arr.ind = TRUE)] <- 1
     }
     
     for (i in q_seq) {
-      S_deriv[[i]][which(x$S$labels == param_names[i], arr.ind = TRUE)] <- 1
+#      S_deriv[[i]][which(x$S$labels == param_names[i], arr.ind = TRUE)] <- 1
+      S_deriv[[i]][which(isTRUE(x$S$free), arr.ind = TRUE)] <- 1
     }
     
     for (i in q_seq) {
-      m_deriv[[i]][which(x$M$labels == param_names[i])] <- 1
+#      m_deriv[[i]][which(x$M$labels == param_names[i])] <- 1
+      m_deriv[[i]][which(isTRUE(x$M$labels))] <- 1
     }
     
     scores_info <- list(p = p, mean_structure = mean_structure, p_star = p_star,


### PR DESCRIPTION
The following code does not work with current `semtree` and score-based tests because the model has no labelled parameters. Thus, the score computation returns only zeros and the tree will find no split. I suggest that we identify free parameters not by whether their labels match in the OpenMx matrices but whether the `free` matrix has respective entries of true or false.

```
library(OpenMx)
library(semtree)

set.seed(2349)

manifests<-c("DeltaPA")
latents<-c()
model <- mxModel("Simple Model", 
                 type="RAM",
                 manifestVars = manifests,
                 latentVars = latents,
                 mxPath(from="one",to=manifests,
                        free=c(TRUE), 
                        value=c(1.0) , arrows=1#, 
                       # label=c("mu") 
                        ),
                 mxPath(from=manifests,to=manifests,
                        free=c(TRUE), value=c(1.0) , 
                        arrows=2#, 
                       # label=c("sigma2") 
                        ),
                 mxData(tree.data, type = "raw")
);
fitted <- mxRun(model)
ctrl = semtree.control(
  method="score", 
  bonferroni = TRUE)
tree = semtree( model = model, 
                data = tree.data, 
                control=ctrl)

```