### PR TITLE
Fix typos and improve test

### DIFF
--- a/CONTRIBUTE.md
+++ b/CONTRIBUTE.md
@@ -31,4 +31,3 @@ this in your local semtree directory:
 devtools::check(".")
 ```
 - please use camel case for function names indicating the separation of words with a single capitalized letter, and the first word starting with lower case, e.g., `checkBinSize()` or `getExpectedMean()`.
-- 

--- a/R/semforest.R
+++ b/R/semforest.R
@@ -63,7 +63,7 @@ semforest <- function(model,
   }
   
   if ("with.error.handler" %in% names(arguments)) {
-    with.error.handler <- arguments$with.error.handle
+    with.error.handler <- arguments$with.error.handler
   } else {
     with.error.handler <- TRUE
   }
@@ -124,7 +124,7 @@ semforest <- function(model,
   # pass mtry from forest to tree control
   if (!is.na(semforest.control$semtree.control$mtry)) {
     ui_stop(
-      "mtry manualy set in  semforest.control$semtree.control object! Please set mtry in semforest.control object only!"
+      "mtry manually set in semforest.control$semtree.control object! Please set mtry in semforest.control object only!"
     )
   }
   semforest.control$semtree.control$mtry <- semforest.control$mtry

--- a/tests/testthat/test-vim2.R
+++ b/tests/testthat/test-vim2.R
@@ -1,91 +1,50 @@
-testthat::skip_on_cran()
+ testthat::skip_on_cran()
 
-set.seed(789)
-require("semtree")
-data(lgcm)
+ test_that("varimp returns expected structure", {
+   set.seed(789)
+   data(lgcm)
+   lgcm$agegroup <- ordered(lgcm$agegroup)
+   lgcm$training <- factor(lgcm$training)
+   lgcm$noise <- factor(lgcm$noise)
+   lgcm$noise2 <- factor(sample(c(0,1,2), nrow(lgcm), TRUE))
 
-lgcm$agegroup <- ordered(lgcm$agegroup)
-lgcm$training <- factor(lgcm$training)
-lgcm$noise <- factor(lgcm$noise)
-lgcm$noise2 <- factor(sample(c(0,1,2), nrow(lgcm),TRUE))
+   manifests <- names(lgcm)[1:5]
+   lgcModel <- mxModel(
+     "Linear Growth Curve Model Path Specification",
+     type = "RAM",
+     manifestVars = manifests,
+     latentVars = c("intercept", "slope"),
+     mxPath(from = manifests, arrows = 2, free = TRUE,
+            values = c(1, 1, 1, 1, 1),
+            labels = c("residual1", "residual2", "residual3", "residual4", "residual5")),
+     mxPath(from = c("intercept", "slope"), connect = "unique.pairs",
+            arrows = 2, free = TRUE, values = c(1, 1, 1),
+            labels = c("vari", "cov", "vars")),
+     mxPath(from = "intercept", to = manifests,
+            arrows = 1, free = FALSE, values = c(1, 1, 1, 1, 1)),
+     mxPath(from = "slope", to = manifests,
+            arrows = 1, free = FALSE, values = c(0, 1, 2, 3, 4)),
+     mxPath(from = "one", to = manifests,
+            arrows = 1, free = FALSE, values = c(0, 0, 0, 0, 0)),
+     mxPath(from = "one", to = c("intercept", "slope"),
+            arrows = 1, free = TRUE, values = c(1, 1),
+            labels = c("meani", "means")),
+     mxData(lgcm, type = "raw")
+   )
 
-# LOAD IN OPENMX MODEL.
-# A SIMPLE LINEAR GROWTH MODEL WITH 5 TIME POINTS FROM SIMULATED DATA
+   ctrl <- semforest.control(num.trees = 10)
+   ctrl$semtree.control$method <- "score"
 
-manifests <- names(lgcm)[1:5]
-lgcModel <- mxModel("Linear Growth Curve Model Path Specification",
-                    type="RAM",
-                    manifestVars=manifests,
-                    latentVars=c("intercept","slope"),
-                    # residual variances
-                    mxPath(
-                      from=manifests,
-                      arrows=2,
-                      free=TRUE,
-                      values = c(1, 1, 1, 1, 1),
-                      labels=c("residual1","residual2","residual3","residual4","residual5")
-                    ),
-                    # latent variances and covariance
-                    mxPath(
-                      from=c("intercept","slope"),
-                      connect="unique.pairs",
-                      arrows=2,
-                      free=TRUE,
-                      values=c(1, 1, 1),
-                      labels=c("vari", "cov", "vars")
-                    ),
-                    # intercept loadings
-                    mxPath(
-                      from="intercept",
-                      to=manifests,
-                      arrows=1,
-                      free=FALSE,
-                      values=c(1, 1, 1, 1, 1)
-                    ),
-                    # slope loadings
-                    mxPath(
-                      from="slope",
-                      to=manifests,
-                      arrows=1,
-                      free=FALSE,
-                      values=c(0, 1, 2, 3, 4)
-                    ),
-                    # manifest means
-                    mxPath(
-                      from="one",
-                      to=manifests,
-                      arrows=1,
-                      free=FALSE,
-                      values=c(0, 0, 0, 0, 0)
-                    ),
-                    # latent means
-                    mxPath(
-                      from="one",
-                      to=c("intercept", "slope"),
-                      arrows=1,
-                      free=TRUE,
-                      values=c(1, 1),
-                      labels=c("meani", "means")
-                    ),
-                    mxData(lgcm,type="raw")
-)
+   fr <- semforest(lgcModel, lgcm, control = ctrl)
+   vimp <- varimp(fr)
 
-ctrl <-  semforest.control(num.trees = 10)
-ctrl$semtree.control$method <- "score"
+   expect_true(is.list(vimp))
+   expect_true(all(c("var.names", "importance") %in% names(vimp)))
 
-fr <- semforest(lgcModel, lgcm, control = ctrl)
+   lgcm <- lgcm[, sample(1:ncol(lgcm), ncol(lgcm), FALSE)]
+   fr2 <- semforest(lgcModel, lgcm, control = ctrl)
+   vimp2 <- varimp(fr2)
 
-
-vimp <- varimp(fr)
-
-print(vimp)
-print(vimp, na.omit=TRUE)
-
-# reorder dataset
-
-lgcm <- lgcm[, sample(1:ncol(lgcm),ncol(lgcm),FALSE)]
-fr2 <- semforest(lgcModel, lgcm, control = ctrl)
-vimp2 <- varimp(fr2)
-
-print(vimp, scale="relative.baseline")
-print(vimp2, scale="relative.baseline")
+   expect_true(is.list(vimp2))
+   expect_true(all(c("var.names", "importance") %in% names(vimp2)))
+ })


### PR DESCRIPTION
## Summary
- fix typo in semforest options
- handle with.error.handler argument correctly
- clean CONTRIBUTE instructions
- convert varimp example into real test

## Testing
- `R -q -e 'devtools::test()'` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686639744f24832c8d85541c889e53e0