### PR TITLE
Improve predictor validation and model type handling

### DIFF
--- a/R/getModelType.R
+++ b/R/getModelType.R
@@ -1,13 +1,12 @@
 getModelType <- function(model)
 {
-  if (inherits(model,"MxModel") || inherits(model,"MxRAMModel")) {
+  if (inherits(model, "MxModel") || inherits(model, "MxRAMModel")) {
     return("OpenMx")
-    control$sem.prog = "OpenMx"
-  } else if (inherits(model,"lavaan")){
+  } else if (inherits(model, "lavaan")) {
     return("lavaan")
-  } else if ((inherits(model,"ctsemFit")) || (inherits(model,"ctsemInit"))) {
+  } else if (inherits(model, "ctsemFit") || inherits(model, "ctsemInit")) {
     return("ctsem")
   } else {
-    ui_stop("Unknown model type selected. Use OpenMx or lavaanified lavaan models!");
+    ui_stop("Unknown model type selected. Use OpenMx or lavaanified lavaan models!")
   }
 }

--- a/R/getPredictorsLavaan.R
+++ b/R/getPredictorsLavaan.R
@@ -2,9 +2,9 @@ getPredictorsLavaan <- function(model, dataset, covariates)
 {
   # specify covariates from model columns
   if (is.null(covariates)) {    
-    model.ids <- rep(NA, length(model@Data@ov.names[[1]]))
-    for (i in 1:length(model.ids)) {
-      model.ids[i] <- which(model@Data@ov.names[[1]][i] == names(dataset));
+    model.ids <- rep(NA_integer_, length(model@Data@ov.names[[1]]))
+    for (i in seq_along(model.ids)) {
+      model.ids[i] <- which(model@Data@ov.names[[1]][i] == names(dataset))
     }
     all.ids <- 1:length(names(dataset))
     cvid <- all.ids[!all.ids %in% model.ids]
@@ -16,7 +16,11 @@ getPredictorsLavaan <- function(model, dataset, covariates)
   # resort columns to organize covariates
   else {
     all.ids <- 1:length(names(dataset))
-    covariate.ids <- sapply(covariates, function(cv) { which(cv==names(dataset))} )
+    covariate.ids <- match(covariates, names(dataset))
+    if (any(is.na(covariate.ids))) {
+      missing_covariates <- paste(covariates[is.na(covariate.ids)], collapse = ", ")
+      ui_stop("Covariate(s) not found in dataset: ", missing_covariates)
+    }
     
     modid <- all.ids[!all.ids %in% covariate.ids]
     if (length(modid)==0) {

--- a/R/getPredictorsOpenMx.R
+++ b/R/getPredictorsOpenMx.R
@@ -2,33 +2,37 @@ getPredictorsOpenMx <- function(mxmodel, dataset, covariates)
 {
   # specify covariates from model columns
   if (is.null(covariates)) {
-    model.ids <- rep(NA, length(mxmodel@manifestVars))
+    model.ids <- rep(NA_integer_, length(mxmodel@manifestVars))
     # find the ids in dataset
-    for (i in 1:length(model.ids)) {
+    for (i in seq_along(model.ids)) {
       cmp <- mxmodel@manifestVars[i] == names(dataset)
       if (all(!cmp)) {
-        ui_stop("Error. Variable ",mxmodel@manifestVars[i], " missing in data set!")
+        ui_stop("Error. Variable ", mxmodel@manifestVars[i], " missing in data set!")
       }
-      model.ids[i] <- which(cmp);
+      model.ids[i] <- which(cmp)
     }
     all.ids <- 1:length(names(dataset))
     cvid <- all.ids[!all.ids %in% model.ids]
     if (length(cvid)==0) {
       ui_stop("Error. No predictors contained in dataset!")
     }
-    covariate.ids <- simplify2array( as.vector(cvid,mode="integer") )
+    covariate.ids <- simplify2array(as.vector(cvid, mode = "integer"))
   }
   # resort columns to organize covariates
   else {
     all.ids <- 1:length(names(dataset))
-    covariate.ids <- sapply(covariates, function(cv) { which(cv==names(dataset))} )
-    
+    covariate.ids <- match(covariates, names(dataset))
+    if (any(is.na(covariate.ids))) {
+      missing_covariates <- paste(covariates[is.na(covariate.ids)], collapse = ", ")
+      ui_stop("Covariate(s) not found in dataset: ", missing_covariates)
+    }
+
     modid <- all.ids[!all.ids %in% covariate.ids]
     if (length(modid)==0) {
       ui_stop("No covariates contained in dataset!")
     }
-    
-    model.ids <- simplify2array( as.vector(modid, mode="integer") )
+
+    model.ids <- simplify2array(as.vector(modid, mode = "integer"))
   }
   
   return(list(model.ids, covariate.ids))


### PR DESCRIPTION
## Summary
- clean up model type detection to remove unreachable code and standardize formatting
- validate OpenMx predictor selection with safer indexing and clearer missing-covariate errors
- update lavaan predictor extraction to guard against missing covariates and 1:length pitfalls

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6926d1cb6b30832cb3a3b7f28420bc73)